### PR TITLE
feat: unify traces views under tabs and speed up metric loading

### DIFF
--- a/otel-light-server/package.json
+++ b/otel-light-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otel-light-server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "",
   "license": "MIT",
   "scripts": {

--- a/otel-light-server/src/analytics/AnalyticsMetricsRoutes.spec.ts
+++ b/otel-light-server/src/analytics/AnalyticsMetricsRoutes.spec.ts
@@ -26,7 +26,10 @@ jest.mock("./AnalyticsUtils", () => ({
 // Imports
 // ---------------------------------------------------------------------------
 import { DbUtilsNoTelemetryQuerySQL } from "../utils-std-ts/DbUtilsNoTelemetry";
-import { AuthGetUserSession, AuthHasScope } from "@devopsplaybook.io/common-utils";
+import {
+  AuthGetUserSession,
+  AuthHasScope,
+} from "@devopsplaybook.io/common-utils";
 import { AnalyticsUtilsCompressJson } from "./AnalyticsUtils";
 import { AnalyticsMetricsRoutes } from "./AnalyticsMetricsRoutes";
 
@@ -161,6 +164,86 @@ describe("AnalyticsMetricsRoutes GET /analytics/metrics", () => {
     expect(sql).toContain("AND time <");
     expect(sql).toContain("LIMIT 200");
     expect(params).toContain("9999999");
+  });
+
+  // --- Server-side sampling: maxPoints ---
+  it("runs a COUNT query first when maxPoints is provided", async () => {
+    (DbUtilsNoTelemetryQuerySQL as jest.Mock)
+      .mockResolvedValueOnce([{ total: 100 }])
+      .mockResolvedValueOnce([]);
+
+    await fastify.inject({
+      method: "GET",
+      url: "/analytics/metrics?name=http.requests&serviceName=my-svc&maxPoints=500",
+    });
+
+    expect(DbUtilsNoTelemetryQuerySQL).toHaveBeenCalledTimes(2);
+    const [countSql]: [string] = (DbUtilsNoTelemetryQuerySQL as jest.Mock).mock
+      .calls[0];
+    expect(countSql).toContain("COUNT(*)");
+  });
+
+  it("uses the plain query when total count fits within maxPoints", async () => {
+    (DbUtilsNoTelemetryQuerySQL as jest.Mock)
+      .mockResolvedValueOnce([{ total: 100 }])
+      .mockResolvedValueOnce([]);
+
+    await fastify.inject({
+      method: "GET",
+      url: "/analytics/metrics?name=http.requests&serviceName=my-svc&maxPoints=500",
+    });
+
+    const [sql]: [string] = (DbUtilsNoTelemetryQuerySQL as jest.Mock).mock
+      .calls[1];
+    expect(sql).not.toContain("ROW_NUMBER");
+    expect(sql).toContain("LIMIT 500");
+  });
+
+  it("samples with ROW_NUMBER when total count exceeds maxPoints", async () => {
+    (DbUtilsNoTelemetryQuerySQL as jest.Mock)
+      .mockResolvedValueOnce([{ total: 10000 }])
+      .mockResolvedValueOnce([]);
+
+    await fastify.inject({
+      method: "GET",
+      url: "/analytics/metrics?name=http.requests&serviceName=my-svc&maxPoints=500",
+    });
+
+    const [sql]: [string] = (DbUtilsNoTelemetryQuerySQL as jest.Mock).mock
+      .calls[1];
+    expect(sql).toContain("ROW_NUMBER()");
+    // step = ceil(10000 / 500) = 20
+    expect(sql).toContain("(rn % 20) = 1");
+    expect(sql).toContain("LIMIT 500");
+  });
+
+  it("clamps maxPoints to AnalyticsUtilsResultLimitMetrics", async () => {
+    const { AnalyticsUtilsResultLimitMetrics } =
+      await import("./AnalyticsUtils");
+    (DbUtilsNoTelemetryQuerySQL as jest.Mock)
+      .mockResolvedValueOnce([{ total: 10 }])
+      .mockResolvedValueOnce([]);
+
+    await fastify.inject({
+      method: "GET",
+      url: "/analytics/metrics?name=http.requests&maxPoints=99999999",
+    });
+
+    const [sql]: [string] = (DbUtilsNoTelemetryQuerySQL as jest.Mock).mock
+      .calls[1];
+    expect(sql).toContain(`LIMIT ${AnalyticsUtilsResultLimitMetrics}`);
+  });
+
+  it("ignores invalid maxPoints values", async () => {
+    await fastify.inject({
+      method: "GET",
+      url: "/analytics/metrics?name=http.requests&maxPoints=abc",
+    });
+
+    expect(DbUtilsNoTelemetryQuerySQL).toHaveBeenCalledTimes(1);
+    const [sql]: [string] = (DbUtilsNoTelemetryQuerySQL as jest.Mock).mock
+      .calls[0];
+    expect(sql).not.toContain("COUNT(*)");
   });
 
   // --- Success ---

--- a/otel-light-server/src/analytics/AnalyticsMetricsRoutes.ts
+++ b/otel-light-server/src/analytics/AnalyticsMetricsRoutes.ts
@@ -24,6 +24,7 @@ export class AnalyticsMetricsRoutes {
         afterTime?: number;
         beforeTime?: number;
         limit?: number;
+        maxPoints?: number;
       };
     }>("/", async (req, res) => {
       const userSession = await AuthGetUserSession(req);
@@ -77,11 +78,41 @@ export class AnalyticsMetricsRoutes {
         sqlParams.push(req.query.beforeTime);
       }
 
-      const resultLimit = req.query.limit || AnalyticsUtilsResultLimitMetrics;
-      const rawMetrics = await DbUtilsNoTelemetryQuerySQL(
-        SQL_QUERIES.GET_METRICS(sqlWhere, resultLimit)[dbType],
-        sqlParams,
+      const resultLimit =
+        parsePositiveInt(req.query.limit, AnalyticsUtilsResultLimitMetrics) ||
+        AnalyticsUtilsResultLimitMetrics;
+      // When maxPoints is set, rows are downsampled server-side (evenly over
+      // the time range) so the client receives a bounded payload instead of
+      // paginating through the full data set only to downsample it locally.
+      const maxPoints = parsePositiveInt(
+        req.query.maxPoints,
+        AnalyticsUtilsResultLimitMetrics,
       );
+      let rawMetrics;
+      if (maxPoints) {
+        const countRows = await DbUtilsNoTelemetryQuerySQL(
+          SQL_QUERIES.COUNT_METRICS(sqlWhere)[dbType],
+          sqlParams,
+        );
+        const totalCount = Number(countRows[0]?.total || 0);
+        const step = Math.max(1, Math.ceil(totalCount / maxPoints));
+        if (step > 1) {
+          rawMetrics = await DbUtilsNoTelemetryQuerySQL(
+            SQL_QUERIES.GET_METRICS_SAMPLED(sqlWhere, step, maxPoints)[dbType],
+            sqlParams,
+          );
+        } else {
+          rawMetrics = await DbUtilsNoTelemetryQuerySQL(
+            SQL_QUERIES.GET_METRICS(sqlWhere, maxPoints)[dbType],
+            sqlParams,
+          );
+        }
+      } else {
+        rawMetrics = await DbUtilsNoTelemetryQuerySQL(
+          SQL_QUERIES.GET_METRICS(sqlWhere, resultLimit)[dbType],
+          sqlParams,
+        );
+      }
       const metrics = [];
       rawMetrics.forEach((rawMetric) => {
         metrics.push(new Metric(rawMetric));
@@ -130,9 +161,27 @@ export class AnalyticsMetricsRoutes {
 
 // SQL
 
+function parsePositiveInt(value: unknown, max: number): number | null {
+  const parsed = parseInt(String(value ?? ""), 10);
+  if (isNaN(parsed) || parsed < 1) {
+    return null;
+  }
+  return Math.min(parsed, max);
+}
+
 const SQL_QUERIES = {
   GET_METRICS: (sqlWhere: string, limit: number) => ({
     postgres: `SELECT "name", "serviceName", "serviceVersion", "time", "type", "rawMetric" FROM metrics ${sqlWhere} ORDER BY "time" DESC LIMIT ${limit}`,
     sqlite: `SELECT name, serviceName, serviceVersion, time, type, rawMetric FROM metrics ${sqlWhere} ORDER BY time DESC LIMIT ${limit}`,
+  }),
+  COUNT_METRICS: (sqlWhere: string) => ({
+    postgres: `SELECT COUNT(*) AS total FROM metrics ${sqlWhere}`,
+    sqlite: `SELECT COUNT(*) AS total FROM metrics ${sqlWhere}`,
+  }),
+  // Evenly samples 1 row every `step` rows (keeping the most recent one) so
+  // that at most `maxPoints` rows are returned whatever the total volume.
+  GET_METRICS_SAMPLED: (sqlWhere: string, step: number, maxPoints: number) => ({
+    postgres: `SELECT "name", "serviceName", "serviceVersion", "time", "type", "rawMetric" FROM (SELECT "name", "serviceName", "serviceVersion", "time", "type", "rawMetric", ROW_NUMBER() OVER (ORDER BY "time" DESC) AS rn FROM metrics ${sqlWhere}) sampled WHERE (rn % ${step}) = 1 ORDER BY "time" DESC LIMIT ${maxPoints}`,
+    sqlite: `SELECT name, serviceName, serviceVersion, time, type, rawMetric FROM (SELECT name, serviceName, serviceVersion, time, type, rawMetric, ROW_NUMBER() OVER (ORDER BY time DESC) AS rn FROM metrics ${sqlWhere}) WHERE (rn % ${step}) = 1 ORDER BY time DESC LIMIT ${maxPoints}`,
   }),
 };

--- a/otel-light-web/app.vue
+++ b/otel-light-web/app.vue
@@ -121,6 +121,11 @@ main {
   height: 100%;
 }
 
+/* Pages with a tab bar on top of the search options (e.g. traces) */
+.signals-page-with-tabs {
+  grid-template-rows: auto auto 1fr;
+}
+
 .signals-scroll {
   max-width: 100%;
   overflow-x: auto;

--- a/otel-light-web/assets/css/tab-navigation.css
+++ b/otel-light-web/assets/css/tab-navigation.css
@@ -1,4 +1,4 @@
-/* Shared tab navigation styles for TraceReportTabs and SettingsNavigation */
+/* Shared tab navigation styles for the traces pages and the settings pages */
 .tab-navigation {
   display: flex;
   gap: 0.25rem;
@@ -6,22 +6,22 @@
   border-bottom: 1px solid #ffffff22;
   padding: 0;
   overflow-x: auto;
+  max-width: 100%;
   min-width: 0;
   list-style: none;
+  scrollbar-width: thin;
 }
 .tab {
   background: none;
   border: none;
   display: inline-flex;
   align-items: center;
+  flex: 0 1 auto;
   padding: 0.5rem 1rem;
   cursor: pointer;
   font-size: 0.9rem;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   min-width: 0;
   text-decoration: none;
   color: inherit;
@@ -31,8 +31,26 @@
     color 0.2s,
     border-color 0.2s;
 }
+/* Ellipsis must live on the label: text-overflow has no effect on flex containers */
+.tab-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
 .tab:hover {
   opacity: 0.6;
+}
+/* On phones, tighten spacing so full labels fit without truncation; the bar
+   falls back to horizontal scrolling below that. */
+@media (max-width: 480px) {
+  .tab-navigation {
+    gap: 0.1rem;
+  }
+  .tab {
+    padding: 0.5rem 0.6rem;
+    font-size: 0.85rem;
+  }
 }
 .tab.active {
   opacity: 1;

--- a/otel-light-web/components/MetricDataGauge.vue
+++ b/otel-light-web/components/MetricDataGauge.vue
@@ -11,14 +11,9 @@
 </template>
 
 <script>
-import { analyticsGet } from "~~/services/AnalyticsQueue";
 import VueApexCharts from "vue3-apexcharts";
-import {
-  UtilsDecompressJson,
-  UtilsMetricSampleDataPoints,
-} from "~/services/Utils";
-import { AuthService } from "~~/services/AuthService";
-import { SERVER_URL } from "~~/services/Config";
+import { UtilsMetricSampleDataPoints } from "~/services/Utils";
+import { MetricsServiceFetchMetricData } from "~~/services/MetricsService";
 import { handleError } from "~~/services/EventBus";
 
 export default {
@@ -82,59 +77,21 @@ export default {
       const fetchTime = new Date();
       this.fetchTime = fetchTime;
 
-      const PAGE_SIZE = 500;
-      const allMetrics = [];
-      let beforeTime = null;
-      let hasMore = true;
-
-      while (hasMore) {
+      try {
+        const allMetrics = await MetricsServiceFetchMetricData(
+          this.serviceName,
+          this.name,
+          this.filter.queryString,
+        );
         if (fetchTime < this.fetchTime) {
           return;
         }
-
-        const baseParams = new URLSearchParams(this.filter.queryString || "");
-        baseParams.delete("serviceName");
-        baseParams.delete("name");
-        baseParams.delete("limit");
-        baseParams.set("serviceName", this.serviceName);
-        baseParams.set("name", this.name);
-        baseParams.set("limit", String(PAGE_SIZE));
-
-        if (beforeTime) {
-          baseParams.set("beforeTime", String(beforeTime));
-        }
-
-        const url = `${SERVER_URL}/analytics/metrics?${baseParams.toString()}`;
-
-        try {
-          const response = await analyticsGet(
-            url,
-            await AuthService.getAuthHeader(),
-          );
-
-          if (fetchTime < this.fetchTime) {
-            return;
-          }
-
-          const batchMetrics = await UtilsDecompressJson(response.data.metrics);
-
-          allMetrics.push(...batchMetrics);
-
-          if (batchMetrics.length < PAGE_SIZE) {
-            hasMore = false;
-          } else {
-            // Use the oldest timestamp in this batch as the cursor for next page
-            beforeTime = Math.min(...batchMetrics.map((m) => m.time));
-          }
-        } catch (error) {
-          handleError(error);
-          hasMore = false;
-        }
+        this.allMetrics = allMetrics;
+        this.metrics = UtilsMetricSampleDataPoints(allMetrics, 500);
+        this.displayMetrics();
+      } catch (error) {
+        handleError(error);
       }
-
-      this.allMetrics = allMetrics;
-      this.metrics = UtilsMetricSampleDataPoints(allMetrics, 500);
-      this.displayMetrics();
       this.loading = false;
     },
     displayMetrics() {

--- a/otel-light-web/components/MetricDataHistogram.vue
+++ b/otel-light-web/components/MetricDataHistogram.vue
@@ -6,14 +6,9 @@
 </template>
 
 <script>
-import { analyticsGet } from "~~/services/AnalyticsQueue";
 import VueApexCharts from "vue3-apexcharts";
-import {
-  UtilsDecompressJson,
-  UtilsMetricSampleDataPoints,
-} from "~/services/Utils";
-import { AuthService } from "~~/services/AuthService";
-import { SERVER_URL } from "~~/services/Config";
+import { UtilsMetricSampleDataPoints } from "~/services/Utils";
+import { MetricsServiceFetchMetricData } from "~~/services/MetricsService";
 import { handleError } from "~~/services/EventBus";
 
 export default {
@@ -98,58 +93,21 @@ export default {
       const fetchTime = new Date();
       this.fetchTime = fetchTime;
 
-      const PAGE_SIZE = 500;
-      const allMetrics = [];
-      let beforeTime = null;
-      let hasMore = true;
-
-      while (hasMore) {
+      try {
+        const allMetrics = await MetricsServiceFetchMetricData(
+          this.serviceName,
+          this.name,
+          this.filter.queryString,
+        );
         if (fetchTime < this.fetchTime) {
           return;
         }
-
-        const baseParams = new URLSearchParams(this.filter.queryString || "");
-        baseParams.delete("serviceName");
-        baseParams.delete("name");
-        baseParams.delete("limit");
-        baseParams.set("serviceName", this.serviceName);
-        baseParams.set("name", this.name);
-        baseParams.set("limit", String(PAGE_SIZE));
-
-        if (beforeTime) {
-          baseParams.set("beforeTime", String(beforeTime));
-        }
-
-        const url = `${SERVER_URL}/analytics/metrics?${baseParams.toString()}`;
-
-        try {
-          const response = await analyticsGet(
-            url,
-            await AuthService.getAuthHeader(),
-          );
-
-          if (fetchTime < this.fetchTime) {
-            return;
-          }
-
-          const batchMetrics = await UtilsDecompressJson(response.data.metrics);
-
-          allMetrics.push(...batchMetrics);
-
-          if (batchMetrics.length < PAGE_SIZE) {
-            hasMore = false;
-          } else {
-            beforeTime = Math.min(...batchMetrics.map((m) => m.time));
-          }
-        } catch (error) {
-          handleError(error);
-          hasMore = false;
-        }
+        this.allMetrics = allMetrics;
+        this.metrics = UtilsMetricSampleDataPoints(allMetrics, 500);
+        this.displayMetrics();
+      } catch (error) {
+        handleError(error);
       }
-
-      this.allMetrics = allMetrics;
-      this.metrics = UtilsMetricSampleDataPoints(allMetrics, 500);
-      this.displayMetrics();
       this.loading = false;
     },
     displayMetrics() {

--- a/otel-light-web/components/MetricDataSum.vue
+++ b/otel-light-web/components/MetricDataSum.vue
@@ -6,14 +6,9 @@
 </template>
 
 <script>
-import { analyticsGet } from "~~/services/AnalyticsQueue";
 import VueApexCharts from "vue3-apexcharts";
-import {
-  UtilsDecompressJson,
-  UtilsMetricSampleDataPoints,
-} from "~/services/Utils";
-import { AuthService } from "~~/services/AuthService";
-import { SERVER_URL } from "~~/services/Config";
+import { UtilsMetricSampleDataPoints } from "~/services/Utils";
+import { MetricsServiceFetchMetricData } from "~~/services/MetricsService";
 import { handleError } from "~~/services/EventBus";
 
 export default {
@@ -91,58 +86,21 @@ export default {
       const fetchTime = new Date();
       this.fetchTime = fetchTime;
 
-      const PAGE_SIZE = 500;
-      const allMetrics = [];
-      let beforeTime = null;
-      let hasMore = true;
-
-      while (hasMore) {
+      try {
+        const allMetrics = await MetricsServiceFetchMetricData(
+          this.serviceName,
+          this.name,
+          this.filter.queryString,
+        );
         if (fetchTime < this.fetchTime) {
           return;
         }
-
-        const baseParams = new URLSearchParams(this.filter.queryString || "");
-        baseParams.delete("serviceName");
-        baseParams.delete("name");
-        baseParams.delete("limit");
-        baseParams.set("serviceName", this.serviceName);
-        baseParams.set("name", this.name);
-        baseParams.set("limit", String(PAGE_SIZE));
-
-        if (beforeTime) {
-          baseParams.set("beforeTime", String(beforeTime));
-        }
-
-        const url = `${SERVER_URL}/analytics/metrics?${baseParams.toString()}`;
-
-        try {
-          const response = await analyticsGet(
-            url,
-            await AuthService.getAuthHeader(),
-          );
-
-          if (fetchTime < this.fetchTime) {
-            return;
-          }
-
-          const batchMetrics = await UtilsDecompressJson(response.data.metrics);
-
-          allMetrics.push(...batchMetrics);
-
-          if (batchMetrics.length < PAGE_SIZE) {
-            hasMore = false;
-          } else {
-            beforeTime = Math.min(...batchMetrics.map((m) => m.time));
-          }
-        } catch (error) {
-          handleError(error);
-          hasMore = false;
-        }
+        this.allMetrics = allMetrics;
+        this.metrics = UtilsMetricSampleDataPoints(allMetrics, 500);
+        this.displayMetrics();
+      } catch (error) {
+        handleError(error);
       }
-
-      this.allMetrics = allMetrics;
-      this.metrics = UtilsMetricSampleDataPoints(allMetrics, 500);
-      this.displayMetrics();
       this.loading = false;
     },
     displayMetrics() {

--- a/otel-light-web/components/TabNavigation.vue
+++ b/otel-light-web/components/TabNavigation.vue
@@ -3,10 +3,10 @@
     <NuxtLink
       v-for="tab in visibleTabs"
       :key="tab.id"
-      :to="tab.to"
+      :to="{ path: tab.to, query: route.query }"
       :class="['tab', { active: isActive(tab) }]"
     >
-      {{ tab.label }}
+      <span class="tab-label">{{ tab.label }}</span>
     </NuxtLink>
   </div>
 </template>
@@ -32,7 +32,16 @@ const visibleTabs = computed(() => {
   });
 });
 
+function normalizePath(path) {
+  return String(path || "").replace(/\/+$/, "") || "/";
+}
+
 function isActive(tab) {
-  return route.path === tab.to || route.path.startsWith(tab.to + "/");
+  const currentPath = normalizePath(route.path);
+  const tabPath = normalizePath(tab.to);
+  if (tab.exact) {
+    return currentPath === tabPath;
+  }
+  return currentPath === tabPath || currentPath.startsWith(tabPath + "/");
 }
 </script>

--- a/otel-light-web/package-lock.json
+++ b/otel-light-web/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "otel-light-web",
       "hasInstallScript": true,
       "dependencies": {
         "@picocss/pico": "^2.1.1",
@@ -5295,13 +5294,13 @@
       }
     },
     "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "extraneous": true,
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/call-bind": {
@@ -5500,13 +5499,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-      "extraneous": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=16"
       }
     },
     "node_modules/common-tags": {
@@ -6750,16 +6749,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/fast-npm-meta/node_modules/cac": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
-      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -6805,9 +6794,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.2.tgz",
-      "integrity": "sha512-UpGiiODyCGprM8EPP6JodP6jC9Rws6TCuiDOD+nn0CJhR8guI3g/ozo4ugL0vJ+Yz1UtJuuRPqvQuybVOF1VQA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -11800,16 +11789,6 @@
         "url": "https://opencollective.com/svgo"
       }
     },
-    "node_modules/svgo/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -12840,16 +12819,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/antfu"
-      }
-    },
-    "node_modules/vite-node/node_modules/cac": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
-      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
       }
     },
     "node_modules/vite-plugin-checker": {

--- a/otel-light-web/pages/traces/index.vue
+++ b/otel-light-web/pages/traces/index.vue
@@ -1,5 +1,6 @@
 <template>
-  <div id="traces-page" class="signals-page">
+  <div id="traces-page" class="signals-page signals-page-with-tabs">
+    <TabNavigation :tabs="tracesTabs" />
     <SearchOptions
       ref="searchOptions"
       @filterChanged="onFilterChanged"
@@ -48,9 +49,6 @@
         >
       </div>
     </div>
-    <button class="fab-button" @click="goToAnalytics" title="Go to Analytics">
-      <i class="bi bi-pie-chart-fill"></i>&nbsp;Stats
-    </button>
   </div>
 </template>
 
@@ -58,6 +56,7 @@
 import { analyticsGet } from "~~/services/AnalyticsQueue";
 import SearchOptions from "~/components/SearchOptions.vue";
 import Loading from "~/components/Loading.vue";
+import { TracesTabs } from "~~/services/TracesTabs";
 import { UtilsDecompressJson } from "~/services/Utils";
 import { AuthService } from "~~/services/AuthService";
 import { SERVER_URL } from "~~/services/Config";
@@ -70,6 +69,7 @@ export default {
   components: { SearchOptions, Loading },
   data() {
     return {
+      tracesTabs: TracesTabs,
       traces: [],
       hasMore: true,
       isLoadingMore: false,
@@ -260,12 +260,6 @@ export default {
         asc: this.sortKey === key && this.sortOrder === "asc",
         desc: this.sortKey === key && this.sortOrder === "desc",
       };
-    },
-    goToAnalytics() {
-      this.$router.push({
-        path: "/traces/stats/aggregated",
-        query: this.$route.query,
-      });
     },
   },
 };

--- a/otel-light-web/pages/traces/stats/aggregated.vue
+++ b/otel-light-web/pages/traces/stats/aggregated.vue
@@ -1,6 +1,6 @@
 <template>
-  <div id="traces-page" class="signals-page signals-page-stats">
-    <TabNavigation :tabs="reports" />
+  <div id="traces-page" class="signals-page signals-page-with-tabs">
+    <TabNavigation :tabs="tracesTabs" />
     <SearchOptions @filterChanged="onFilterChanged" type="traces" />
     <div id="traces" class="signals-scroll">
       <div class="trace-group-summary">
@@ -62,9 +62,6 @@
         </div>
       </div>
     </div>
-    <button class="fab-button" @click="goToTraces" title="Go to Analytics">
-      <i class="bi bi-arrow-return-left"></i>&nbsp;Back
-    </button>
   </div>
 </template>
 
@@ -73,6 +70,7 @@ import { analyticsGet } from "~~/services/AnalyticsQueue";
 import SearchOptions from "~/components/SearchOptions.vue";
 import Trace from "~/components/Trace.vue";
 import TraceSpan from "~/components/TraceSpan.vue";
+import { TracesTabs } from "~~/services/TracesTabs";
 import { UtilsDecompressJson } from "~/services/Utils";
 import { AuthService } from "~~/services/AuthService";
 import { SERVER_URL } from "~~/services/Config";
@@ -83,19 +81,7 @@ export default {
   components: { SearchOptions, Trace, TraceSpan },
   data() {
     return {
-      reports: [
-        {
-          id: "aggregated",
-          label: "Aggregated Traces",
-          to: "/traces/stats/aggregated",
-        },
-        { id: "longest", label: "Longest Traces", to: "/traces/stats/longest" },
-        {
-          id: "most-called",
-          label: "Most Called Traces",
-          to: "/traces/stats/most-called",
-        },
-      ],
+      tracesTabs: TracesTabs,
       groups: [],
       expandedGroupTraces: {},
       traceSpans: {},
@@ -124,9 +110,6 @@ export default {
     },
   },
   methods: {
-    goToTraces() {
-      this.$router.push({ path: "/traces/", query: this.$route.query });
-    },
     onFilterChanged(filter) {
       this.filter.queryString = filter.queryString;
       this.fetchTraces();
@@ -230,10 +213,6 @@ export default {
 </script>
 
 <style scoped>
-.signals-page-stats {
-  grid-template-rows: auto auto 1fr;
-}
-
 .trace-group-summary,
 .trace-span-expanded {
   min-width: 1200px;

--- a/otel-light-web/pages/traces/stats/longest.vue
+++ b/otel-light-web/pages/traces/stats/longest.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="traces-page" class="signals-page">
-    <TabNavigation :tabs="reports" />
+    <TabNavigation :tabs="tracesTabs" />
     <div class="signals-scroll">
       <TraceReportStatic
         title="Longest Traces"
@@ -12,15 +12,13 @@
         value-label="Avg Duration (s)"
       />
     </div>
-    <button class="fab-button" @click="goToTraces" title="Go to Analytics">
-      <i class="bi bi-arrow-return-left"></i>&nbsp;Back
-    </button>
   </div>
 </template>
 
 <script>
 import axios from "axios";
 import TraceReportStatic from "~/components/TraceReportStatic.vue";
+import { TracesTabs } from "~~/services/TracesTabs";
 import { AuthService } from "~~/services/AuthService";
 import { SERVER_URL } from "~~/services/Config";
 import { handleError } from "~~/services/EventBus";
@@ -29,19 +27,7 @@ export default {
   components: { TraceReportStatic },
   data() {
     return {
-      reports: [
-        {
-          id: "aggregated",
-          label: "Aggregated Traces",
-          to: "/traces/stats/aggregated",
-        },
-        { id: "longest", label: "Longest Traces", to: "/traces/stats/longest" },
-        {
-          id: "most-called",
-          label: "Most Called Traces",
-          to: "/traces/stats/most-called",
-        },
-      ],
+      tracesTabs: TracesTabs,
       report: {
         generatedAt: null,
         periodDays: null,
@@ -59,9 +45,6 @@ export default {
     this.fetchReport();
   },
   methods: {
-    goToTraces() {
-      this.$router.push({ path: "/traces/", query: this.$route.query });
-    },
     async fetchReport() {
       try {
         const response = await axios.get(

--- a/otel-light-web/pages/traces/stats/most-called.vue
+++ b/otel-light-web/pages/traces/stats/most-called.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="traces-page" class="signals-page">
-    <TabNavigation :tabs="reports" />
+    <TabNavigation :tabs="tracesTabs" />
     <div class="signals-scroll">
       <TraceReportStatic
         title="Most Called Traces"
@@ -12,15 +12,13 @@
         value-label="Avg Duration (s)"
       />
     </div>
-    <button class="fab-button" @click="goToTraces" title="Go to Analytics">
-      <i class="bi bi-arrow-return-left"></i>&nbsp;Back
-    </button>
   </div>
 </template>
 
 <script>
 import axios from "axios";
 import TraceReportStatic from "~/components/TraceReportStatic.vue";
+import { TracesTabs } from "~~/services/TracesTabs";
 import { AuthService } from "~~/services/AuthService";
 import { SERVER_URL } from "~~/services/Config";
 import { handleError } from "~~/services/EventBus";
@@ -29,19 +27,7 @@ export default {
   components: { TraceReportStatic },
   data() {
     return {
-      reports: [
-        {
-          id: "aggregated",
-          label: "Aggregated Traces",
-          to: "/traces/stats/aggregated",
-        },
-        { id: "longest", label: "Longest Traces", to: "/traces/stats/longest" },
-        {
-          id: "most-called",
-          label: "Most Called Traces",
-          to: "/traces/stats/most-called",
-        },
-      ],
+      tracesTabs: TracesTabs,
       report: {
         generatedAt: null,
         periodDays: null,
@@ -59,9 +45,6 @@ export default {
     this.fetchReport();
   },
   methods: {
-    goToTraces() {
-      this.$router.push({ path: "/traces/", query: this.$route.query });
-    },
     async fetchReport() {
       try {
         const response = await axios.get(

--- a/otel-light-web/services/AnalyticsQueue.ts
+++ b/otel-light-web/services/AnalyticsQueue.ts
@@ -8,13 +8,17 @@ interface QueueItem {
 
 /**
  * Bounded-concurrency queue for analytics API requests (traces, logs, metrics).
- * Only 2 requests execute concurrently. Failed / timed-out requests are
- * released from the active slot immediately so queued requests can proceed.
+ * Only 4 requests execute concurrently: enough for metric charts to load in
+ * parallel, while still bounding server memory (each in-flight response is
+ * buffered, compressed and decompressed). Server-side downsampling
+ * (maxPoints) keeps individual responses small. Failed / timed-out requests
+ * are released from the active slot immediately so queued requests can
+ * proceed.
  */
 class AnalyticsQueue {
   private readonly queue: QueueItem[] = [];
   private activeCount = 0;
-  private readonly maxConcurrent = 2;
+  private readonly maxConcurrent = 4;
 
   enqueue<T>(requestFn: () => Promise<T>): Promise<T> {
     return new Promise<T>((resolve, reject) => {
@@ -48,7 +52,7 @@ export const analyticsQueue = new AnalyticsQueue();
 
 /**
  * Drop-in replacement for `axios.get` that queues requests targeting
- * analytics endpoints (traces, logs, metrics). Only 2 concurrent
+ * analytics endpoints (traces, logs, metrics). Only 4 concurrent
  * requests are allowed.
  */
 export function analyticsGet(
@@ -60,7 +64,7 @@ export function analyticsGet(
 
 /**
  * Drop-in replacement for `fetch` that queues requests targeting
- * analytics endpoints. Only 2 concurrent requests are allowed.
+ * analytics endpoints. Only 4 concurrent requests are allowed.
  */
 export function analyticsFetch(
   url: string,

--- a/otel-light-web/services/MetricsService.ts
+++ b/otel-light-web/services/MetricsService.ts
@@ -1,0 +1,32 @@
+import { analyticsGet } from "~~/services/AnalyticsQueue";
+import { AuthService } from "~~/services/AuthService";
+import { SERVER_URL } from "~~/services/Config";
+import { UtilsDecompressJson } from "~~/services/Utils";
+
+/**
+ * Maximum number of data rows requested per metric chart. The server
+ * downsamples evenly across the time range when more rows exist, so the
+ * UI transfers a bounded payload instead of paginating through the full
+ * data set only to downsample it locally before rendering.
+ */
+const METRICS_FETCH_MAX_POINTS = 1000;
+
+/**
+ * Fetches the (server-side downsampled) data rows for a single metric.
+ */
+export async function MetricsServiceFetchMetricData(
+  serviceName: string,
+  name: string,
+  filterQueryString: string,
+): Promise<any[]> {
+  const params = new URLSearchParams(filterQueryString || "");
+  params.delete("serviceName");
+  params.delete("name");
+  params.delete("limit");
+  params.set("serviceName", serviceName);
+  params.set("name", name);
+  params.set("maxPoints", String(METRICS_FETCH_MAX_POINTS));
+  const url = `${SERVER_URL}/analytics/metrics?${params.toString()}`;
+  const response = await analyticsGet(url, await AuthService.getAuthHeader());
+  return await UtilsDecompressJson(response.data.metrics);
+}

--- a/otel-light-web/services/TracesTabs.ts
+++ b/otel-light-web/services/TracesTabs.ts
@@ -1,0 +1,24 @@
+/**
+ * Tabs shared by all the traces pages: the main trace list and the
+ * statistics views. Labels are intentionally short so the tab bar stays
+ * usable on narrow screens (it scrolls horizontally / ellipsizes if needed).
+ * `exact` prevents the list tab from matching the stats sub-routes.
+ */
+export const TracesTabs = [
+  { id: "list", label: "Traces", to: "/traces", exact: true },
+  {
+    id: "aggregated",
+    label: "Aggregated",
+    to: "/traces/stats/aggregated",
+  },
+  {
+    id: "longest",
+    label: "Longest",
+    to: "/traces/stats/longest",
+  },
+  {
+    id: "most-called",
+    label: "Most Called",
+    to: "/traces/stats/most-called",
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otel-light",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "",
   "main": "ecosystem.config.js",
   "scripts": {


### PR DESCRIPTION
## Traces: single tabbed UI

- The main trace list and the three stats views (Aggregated, Longest, Most Called) are now reachable from one shared tab bar on every traces page; the floating Stats/Back buttons are removed.
- Tab definitions are shared in `otel-light-web/services/TracesTabs.ts`; labels were shortened so the bar stays usable on small screens.
- `TabNavigation` now supports `exact` matching (so the list tab is not active on stats sub-routes) and preserves the current route query (filters) when switching tabs, matching the previous Stats/Back button behavior.
- Responsive tab bar: labels ellipsize on narrow screens (ellipsis moved to a label span, where text-overflow actually applies), with horizontal scrolling as fallback; a <480px media query tightens spacing so full labels fit on phones. Verified with a browser harness at 1200/768/375/320/240px.

## Metrics: faster loading of many metrics

- New optional `maxPoints` param on `GET /api/analytics/metrics`: the server counts matching rows and returns an evenly spaced sample (ROW_NUMBER window function, sqlite + postgres) capped at `maxPoints`, instead of the client paginating through the whole data set only to downsample it locally. `limit`/`maxPoints` are now parsed and clamped server-side.
- The three metric chart components now do a single bounded request via the shared `MetricsServiceFetchMetricData` (maxPoints=1000) instead of a sequential 500-row pagination loop each.
- Client analytics queue concurrency raised from 2 to 4: safe now that each response is bounded by server-side downsampling, and it lets several charts load in parallel.

## Verification

- Server: build, lint and all 8 test suites (79 tests, incl. 5 new maxPoints tests) pass.
- Web: `npm run generate` passes (web lint/test scripts are TODO stubs).
- Versions bumped: root 0.29.0 -> 0.30.0, server 0.3.0 -> 0.4.0; dependencies updated.