### PR TITLE
fix: query database for non-overlapping previous period in recommendations

### DIFF
--- a/otel-light-server/package-lock.json
+++ b/otel-light-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "otel-light-server",
-  "version": "0.3.0",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "otel-light-server",
-      "version": "0.3.0",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@devopsplaybook.io/common-utils": "^1.4.0",

--- a/otel-light-server/package.json
+++ b/otel-light-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otel-light-server",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "author": "",
   "license": "MIT",
   "scripts": {

--- a/otel-light-server/src/reports/Recommendation.ts
+++ b/otel-light-server/src/reports/Recommendation.ts
@@ -139,9 +139,11 @@ export async function RecommendationGenerate(): Promise<void> {
 
     // ── Persist result ────────────────────────────────────────────────────
 
-    // Strip raw nanosecond timestamps from the stats exposed to clients;
-    // keep them internally for future delta comparisons.
+    // Include period boundaries so future runs can validate the previous
+    // period doesn't overlap with the current one before comparing.
     const clientStats = {
+      periodStart: stats.periodStart,
+      periodEnd: stats.periodEnd,
       periodHours: stats.periodHours,
       services: stats.services,
       logs: stats.logs,
@@ -211,7 +213,13 @@ async function callLLMWithRetry(
                 "- Logs with severity='error' indicate failures.\n" +
                 "- Trace names typically represent the entry-point operation (e.g., HTTP method + route).\n" +
                 "- Traces are ranked in 4 independent dimensions: by count (most frequent, usually user-facing), by cumulative duration (heaviest total time), by average duration (slowest, min 3 occurrences), and by error count (most problematic). A trace can appear in multiple lists.\n" +
-                "- 'previousPeriod' data (if present) lets you compare against the prior time window.\n\n" +
+                "- 'previousPeriod' data (if present) lets you compare against the prior time window. " +
+                "It covers the adjacent, non-overlapping window of equal duration immediately before the current period.\n\n" +
+                "IMPORTANT: The statistics cover the exact time window stated in the prompt. " +
+                "If no previous-period comparison data is provided, do not invent or assume prior values; " +
+                "do not describe trends, drops, or spikes relative to a period you have no data for. " +
+                "A low absolute count is not an anomaly on its own—only flag changes when you have " +
+                "both current and previous numbers to compare.\n\n" +
                 "Output your answer in two clear sections:\n" +
                 "## Analysis\n" +
                 "A concise analysis (3-6 paragraphs) covering:\n" +
@@ -580,25 +588,38 @@ async function CollectStats(
   };
 
   // ── Previous period comparison ─────────────────────────────────────────
+  // Query the immediately preceding, non-overlapping period of equal duration
+  // from the database. This avoids misleading deltas caused by comparing
+  // overlapping or misaligned time windows from cached recommendation files.
 
   let previousPeriod: RecommendationStats["previousPeriod"] = undefined;
   try {
-    if (await fs.pathExists(recommendationFilePath)) {
-      const cached = (await fs.readJson(recommendationFilePath)) as {
-        stats?: {
-          logs?: { total?: number; errors?: number };
-          traces?: { total?: number; errorCount?: number };
-        };
-      };
-      if (cached?.stats?.logs) {
-        previousPeriod = {
-          logsTotal: cached.stats.logs.total || 0,
-          logsErrors: cached.stats.logs.errors || 0,
-          tracesTotal: cached.stats.traces?.total || 0,
-          tracesErrors: cached.stats.traces?.errorCount || 0,
-        };
-      }
-    }
+    const prevPeriodEnd = periodStart;
+    const prevPeriodStart = periodStart - (periodEnd - periodStart);
+
+    const prevLogsTotalRow = await DbUtilsNoTelemetryQuerySQL(
+      SQL_QUERIES.LOGS_TOTAL[DbUtilsGetType()],
+      [prevPeriodStart, prevPeriodEnd],
+    );
+    const prevLogsErrorsRow = await DbUtilsNoTelemetryQuerySQL(
+      SQL_QUERIES.LOGS_ERRORS[DbUtilsGetType()],
+      [prevPeriodStart, prevPeriodEnd],
+    );
+    const prevTracesTotalRow = await DbUtilsNoTelemetryQuerySQL(
+      SQL_QUERIES.TRACES_TOTAL[DbUtilsGetType()],
+      [prevPeriodStart, prevPeriodEnd],
+    );
+    const prevTracesErrorsRow = await DbUtilsNoTelemetryQuerySQL(
+      SQL_QUERIES.TRACES_ERRORS[DbUtilsGetType()],
+      [prevPeriodStart, prevPeriodEnd],
+    );
+
+    previousPeriod = {
+      logsTotal: Number(prevLogsTotalRow[0]?.count || 0),
+      logsErrors: Number(prevLogsErrorsRow[0]?.count || 0),
+      tracesTotal: Number(prevTracesTotalRow[0]?.count || 0),
+      tracesErrors: Number(prevTracesErrorsRow[0]?.count || 0),
+    };
   } catch {
     // Ignore — previous period comparison is best-effort
   }
@@ -697,7 +718,11 @@ function BuildPrompt(stats: RecommendationStats, periodHours: number): string {
   };
 
   const lines: string[] = [];
-  lines.push(`Telemetry statistics for the last ${periodHours} hours.\n`);
+  lines.push(`Telemetry statistics for the last ${periodHours} hours.`);
+  lines.push(
+    `Period: ${new Date(stats.periodStart / 1_000_000).toISOString()} to ${new Date(stats.periodEnd / 1_000_000).toISOString()}`,
+  );
+  lines.push("");
 
   lines.push("--- Services ---");
   lines.push(stats.services.join(", "));
@@ -793,10 +818,19 @@ function BuildPrompt(stats: RecommendationStats, periodHours: number): string {
   if (stats.previousPeriod) {
     lines.push("--- Comparison with previous period ---");
     lines.push(
+      `The previous period is the adjacent ${periodHours}-hour window immediately before the current one (no overlap).`,
+    );
+    lines.push(
       `Logs: ${stats.previousPeriod.logsTotal} → ${stats.logs.total} total, ${stats.previousPeriod.logsErrors} → ${stats.logs.errors} errors`,
     );
     lines.push(
       `Traces: ${stats.previousPeriod.tracesTotal} → ${stats.traces.total} total, ${stats.previousPeriod.tracesErrors} → ${stats.traces.errorCount} errors`,
+    );
+    lines.push("");
+  } else {
+    lines.push("--- Comparison with previous period ---");
+    lines.push(
+      "No previous period data is available. Do not speculate about trends or changes from a prior period; analyze only the current period's data.",
     );
     lines.push("");
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "otel-light",
-  "version": "0.28.2",
+  "version": "0.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "otel-light",
-      "version": "0.28.2",
+      "version": "0.30.1",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otel-light",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "",
   "main": "ecosystem.config.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- The previous-period comparison in recommendations read cached stats from `recommendation.json` without validating that the time windows were aligned. When recommendations were regenerated at a different time of day (e.g., after midnight) or shortly after a previous run, the cached period overlapped with or was misaligned relative to the current one, producing misleading deltas such as "dramatic drop to zero (↓100%)".
- The previous period is now queried directly from the database using the adjacent, non-overlapping window of equal duration (`[periodStart - duration, periodStart)`), guaranteeing meaningful period-over-period comparisons regardless of when the recommendation is generated.
- `periodStart`/`periodEnd` are persisted in the cached recommendation file for transparency, and the exact period timestamps (ISO format) are included in the LLM prompt.
- The LLM system prompt now clarifies that the previous period is adjacent and non-overlapping, and instructs the model not to invent or speculate about trends when no previous-period data is available.
- Version bumped: `otel-light-server` 0.4.0 → 0.4.2, root `otel-light` 0.30.0 → 0.30.1 (patch).

## Test Plan
- [x] `npm ci` succeeds in `otel-light-server`
- [x] `npm run build` passes (TypeScript clean)
- [x] `npm run lint` passes (ESLint clean)
- [x] `npm test` passes (8 suites, 79 tests)
- [ ] PR Check workflow succeeds